### PR TITLE
Fix build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # browserify-as-a-service
 
-[![Build Status](https://travis-ci.org/jfhbrook/wzrd.in.png?branch=master)](https://travis-ci.org/jfhbrook/wzrd.in)
+[![Build Status](https://travis-ci.org/browserify/wzrd.in.png?branch=master)](https://travis-ci.org/browserify/wzrd.in)
 
 #### Places
 


### PR DESCRIPTION
Updates the Travis CI build status badge to point to the current repo.