### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/bundler/registry.js
+++ b/bundler/registry.js
@@ -16,7 +16,7 @@ var registry = module.exports = function get(module, version, cb) {
 // Define the registry that will be used for installing npm packages
 //
 var registryURL = process.env.REGISTRY || 'http://registry.npmjs.org/';
-if (registryURL.substr(-1) !== '/') {
+if (registryURL.slice(-1) !== '/') {
   registryURL += '/';
 }
 registry.registryURL = registryURL;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.